### PR TITLE
Fix condition for when to rerun the template encoder

### DIFF
--- a/mhnreact/model.py
+++ b/mhnreact/model.py
@@ -352,7 +352,7 @@ class MHN(nn.Module):
         if (templates is None) and (self.X is None) and (self.templates is None):
             raise Exception('Either pass in templates, or init templates by runnting clf.set_templates')
         n_temp = len(templates) if templates is not None else len(self.templates)
-        if self.training or (templates is None) or (self.X is not None):
+        if self.training or (templates is not None) or (self.X is None):
             templates = templates if templates is not None else self.templates
             X = self.template_encoder(templates)
         else:

--- a/mhnreact/model.py
+++ b/mhnreact/model.py
@@ -346,9 +346,9 @@ class MHN(nn.Module):
         templates: None or newly given templates if not instanciated
         returns logits ranking the templates for each molecule
         """
-        #states_emb = self.fcfe(state_fp)
+
         bs = m.shape[0] #batch_size
-        #templates = self.temp_emb(torch.arange(0,2000).long())
+
         if (templates is None) and (self.X is None) and (self.templates is None):
             raise Exception('Either pass in templates, or init templates by runnting clf.set_templates')
         n_temp = len(templates) if templates is not None else len(self.templates)


### PR DESCRIPTION
When running another `forward` pass without changing the set of templates, it's useful to be able to reuse the (already computed) template encodings. The model code already supports that possibility, but due to incorrect `if` conditions it cannot be accessed; I'm fixing these here.

Now if one manually sets the `X` attribute of the model, and the `templates` are not provided, computing the template encodings will be skipped. I tested that I can indeed get a visible speedup through this when running multiple forward passes with the same template set.